### PR TITLE
Make blog publication date prominent than the update date

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -29,6 +29,9 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.head_ref }}
+          # Required by jekyll-last-modified-at to find the commit that
+          # actually last changed each post instead of using the build commit.
+          fetch-depth: 0
 
       - name: Install Ruby packages
         if: github.event.action != 'closed'

--- a/.github/workflows/build-site.yaml
+++ b/.github/workflows/build-site.yaml
@@ -25,6 +25,10 @@ jobs:
 
       - name: Checkout branch contents
         uses: actions/checkout@v5
+        with:
+          # Required by jekyll-last-modified-at to find the commit that
+          # actually last changed each post instead of using the build commit.
+          fetch-depth: 0
 
       - name: Install Ruby packages
         uses: ruby/setup-ruby@v1

--- a/_includes/post-info.html
+++ b/_includes/post-info.html
@@ -26,16 +26,18 @@
   {% assign updated = include.updated | date: "%B %d, %Y" %}
 
   {% if published %}
-    <span data-tooltip="Originally published on">
+    <span class="post-info-published" data-tooltip="Publication date">
       {% include icon.html icon="fa-regular fa-calendar" %}
-      <span>{{ published }}</span>
+      <span class="post-info-label">Published</span>
+      <time datetime="{{ include.published | date_to_xmlschema }}">{{ published }}</time>
     </span>
   {% endif %}
 
   {% if updated and updated != "" and updated != published %}
-    <span data-tooltip="Last updated on">
+    <span class="post-info-updated" data-tooltip="Last updated date">
       {% include icon.html icon="fa-solid fa-clock-rotate-left" %}
-      <span>{{ updated }}</span>
+      <span class="post-info-label">Updated</span>
+      <time datetime="{{ include.updated | date_to_xmlschema }}">{{ updated }}</time>
     </span>
   {% endif %}
 </div>

--- a/_styles/post-info.scss
+++ b/_styles/post-info.scss
@@ -31,3 +31,21 @@
   text-align: center;
   white-space: nowrap;
 }
+
+.post-info .post-info-published {
+  color: var(--text);
+  font-weight: var(--bold);
+}
+
+.post-info .post-info-published .icon {
+  color: var(--primary);
+}
+
+.post-info .post-info-label {
+  margin-right: 0.35em;
+}
+
+.post-info .post-info-updated {
+  color: var(--dark-gray);
+  font-size: 0.85em;
+}


### PR DESCRIPTION
Vorher sah es teilweise so aus, als wären viele Artikel am selben Tag veröffentlicht worden, weil das Updated-Datum angezeigt wurde. Dadurch werden die wahrgenommenen Publikationsdaten fälschlicherweise nach hinten geschoben und ein unaufmerksamer Leser fragt sich, wieso die diese Sachen erst so spät und damit noch alle auf einmal veröffentlicht haben.

Jetzt wird das Created-Date sichtbarer angezeigt, siehe Bilder.


Alt: 

<img width="1017" height="285" alt="blog-date-before-card" src="https://github.com/user-attachments/assets/9038ef24-9d85-443a-93e8-d46b1e0586d0" />

Neu:
<img width="1000" height="259" alt="blog-date-after-card" src="https://github.com/user-attachments/assets/1bee318a-0d7c-45fe-86a9-3923af192f99" />
<img width="1284" height="1450" alt="blog-date-before-overview" src="https://github.com/user-attachments/assets/c5e5341b-4d5e-400d-88e0-a85f35150e17" />
<img width="1284" height="1450" alt="blog-date-before-overview" src="https://github.com/user-attachments/assets/91e7bc60-ae78-457d-8957-b6247048a952" />

Neu:
<img width="1280" height="2860" alt="blog-date-after-overview" src="https://github.com/user-attachments/assets/7aa80bce-c4e4-4501-ae7d-6eb4d67d7d0e" />
<img width="1000" height="259" alt="blog-date-after-card" src="https://github.com/user-attachments/assets/894cd1bf-f7f7-4645-93e5-76171e77912e" />
<img width="1284" height="1450" alt="blog-date-before-overview" src="https://github.com/user-attachments/assets/2353f2b1-e2c6-4c6f-b5b9-b12568af4d89" />
<img width="1000" height="259" alt="blog-date-after-card" src="https://github.com/user-attachments/assets/1bee318a-0d7c-45fe-86a9-3923af192f99" />
<img width="1017" height="285" alt="blog-date-before-card" src="https://github.com/user-attachments/assets/86d1f5ac-2d3f-47b9-b30c-4f867e2512f7" />
<img width="1017" height="285" alt="blog-date-before-card" src="https://github.com/user-attachments/assets/c70cc820-6ff2-4124-aa39-5a883aae9c43" />
